### PR TITLE
Add support for unmarshalling int and string slices

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -232,7 +232,7 @@ func setStringSlice(field, value reflect.Value) error {
 	for i := 0; i < value.Len(); i++ {
 		strVal, ok := value.Index(i).Interface().(string)
 		if !ok {
-			return fmt.Errorf("error")
+			return fmt.Errorf("value is not of type string")
 		}
 		arr[i] = strVal
 	}
@@ -247,7 +247,7 @@ func setIntSlice(field, value reflect.Value) error {
 	for i := 0; i < value.Len(); i++ {
 		floatVal, ok := value.Index(i).Interface().(float64)
 		if !ok {
-			return fmt.Errorf("error")
+			return fmt.Errorf("value is not of type float64")
 		}
 		arr[i] = int(floatVal)
 	}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -173,6 +173,13 @@ func unmarshal(resource *Resource, memberType memberType, memberNames []string, 
 		fallthrough
 	case reflect.Float64:
 		return setFloat(field, value)
+	case reflect.Slice:
+		switch field.Type() {
+		case reflect.TypeOf([]string{}):
+			return setStringSlice(field, value)
+		case reflect.TypeOf([]int{}):
+			return setIntSlice(field, value)
+		}
 	}
 	return nil
 }
@@ -216,6 +223,36 @@ func setFloat(field, value reflect.Value) error {
 		return fmt.Errorf("number has no digits")
 	}
 	field.SetFloat(value.Float())
+	return nil
+}
+
+func setStringSlice(field, value reflect.Value) error {
+	arr := make([]string, value.Len(), value.Cap())
+
+	for i := 0; i < value.Len(); i++ {
+		strVal, ok := value.Index(i).Interface().(string)
+		if !ok {
+			return fmt.Errorf("error")
+		}
+		arr[i] = strVal
+	}
+
+	field.Set(reflect.ValueOf(arr))
+	return nil
+}
+
+func setIntSlice(field, value reflect.Value) error {
+	arr := make([]int, value.Len(), value.Cap())
+
+	for i := 0; i < value.Len(); i++ {
+		floatVal, ok := value.Index(i).Interface().(float64)
+		if !ok {
+			return fmt.Errorf("error")
+		}
+		arr[i] = int(floatVal)
+	}
+
+	field.Set(reflect.ValueOf(arr))
 	return nil
 }
 

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -500,6 +500,56 @@ func TestUnmarshalEmbeddedStruct(t *testing.T) {
 	}
 }
 
+func TestIntSlices(t *testing.T) {
+	input := []byte(`{
+		"data": {
+			"id": "someID",
+			"type": "samples",
+			"attributes": {
+				"slice_ints": [5, 10, 1]
+			}
+		}
+	}`)
+	s := Sample{}
+	expectedSlice := []int{5, 10, 1}
+	if err := Unmarshal(input, &s); err != nil {
+		t.Errorf(err.Error())
+	}
+	if len(s.SliceInts) != 3 {
+		t.Errorf("Length of slice incorrect, got %v, want: %v", len(s.SliceInts), 3)
+	}
+	for i, v := range s.SliceInts {
+		if v != expectedSlice[i] {
+			t.Errorf("Slice value incorrect at index %d, got %v, want %v", i, v, expectedSlice[i])
+		}
+	}
+}
+
+func TestStringSlices(t *testing.T) {
+	input := []byte(`{
+		"data": {
+			"id": "someID",
+			"type": "samples",
+			"attributes": {
+				"slice_strings": ["hello", "world", "!"]
+			}
+		}
+	}`)
+	s := Sample{}
+	expectedSlice := []string{"hello", "world", "!"}
+	if err := Unmarshal(input, &s); err != nil {
+		t.Errorf(err.Error())
+	}
+	if len(s.SliceStrings) != 3 {
+		t.Errorf("Length of slice incorrect, got %v, want: %v", len(s.SliceInts), 3)
+	}
+	for i, v := range s.SliceStrings {
+		if v != expectedSlice[i] {
+			t.Errorf("Slice value incorrect at index %d, got %v, want %v", i, v, expectedSlice[i])
+		}
+	}
+}
+
 func TestUnmarshalCustomType(t *testing.T) {
 	// TODO
 }

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -523,6 +523,26 @@ func TestIntSlices(t *testing.T) {
 			t.Errorf("Slice value incorrect at index %d, got %v, want %v", i, v, expectedSlice[i])
 		}
 	}
+
+	wrongStruct := Sample{}
+	wrongError := "value is not of type float64"
+	wrongInput := []byte(`{
+		"data": {
+			"id": "someID",
+			"type": "samples",
+			"attributes": {
+				"slice_ints": ["hello"]
+			}
+		}
+	}`)
+
+	if err := Unmarshal(wrongInput, &wrongStruct); err == nil {
+		t.Errorf("expected error: %s, go no error", wrongError)
+	} else {
+		if err.Error() != wrongError {
+			t.Errorf("expected error: %s, got: %s", wrongError, err.Error())
+		}
+	}
 }
 
 func TestStringSlices(t *testing.T) {
@@ -546,6 +566,26 @@ func TestStringSlices(t *testing.T) {
 	for i, v := range s.SliceStrings {
 		if v != expectedSlice[i] {
 			t.Errorf("Slice value incorrect at index %d, got %v, want %v", i, v, expectedSlice[i])
+		}
+	}
+
+	wrongStruct := Sample{}
+	wrongError := "value is not of type string"
+	wrongInput := []byte(`{
+		"data": {
+			"id": "someID",
+			"type": "samples",
+			"attributes": {
+				"slice_strings": [2]
+			}
+		}
+	}`)
+
+	if err := Unmarshal(wrongInput, &wrongStruct); err == nil {
+		t.Errorf("expected error: %s, go no error", wrongError)
+	} else {
+		if err.Error() != wrongError {
+			t.Errorf("expected error: %s, got: %s", wrongError, err.Error())
 		}
 	}
 }


### PR DESCRIPTION
This PR adds support for unmarshalling int and string slices within `attribute`

Ex: 
```json
{
    "data": {
        "type": "type",
        "attributes": {
            "ints": [1, 2, 3]
        }
    }
}
```

and 

```json
{
    "data": {
        "type": "type",
        "attributes": {
            "strings": ["some", "strings", "here"]
        }
    }
}
```